### PR TITLE
Upgrade project to Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:21
 WORKDIR /app
 COPY target/*.jar /app/myapp.jar
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<name>bad-religion-quotes-service</name>
 	<description>Bar Religion Quotes Service</description>
 	<properties>
-		<java.version>17</java.version>
+                <java.version>21</java.version>
 		<docker.image.prefix>xavelo</docker.image.prefix>
 		<docker.image.name>bad-religion-quotes-service</docker.image.name>
 	</properties>


### PR DESCRIPTION
## Summary
- set the Maven `java.version` property to 21 so the application compiles against Java 21
- update the Docker image to use the OpenJDK 21 runtime

## Testing
- mvn test *(fails: unable to resolve Spring Boot parent POM from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d920b9f6588329a7d5590502f50ad1