### PR TITLE
Fix controllers to use generated OpenAPI DTOs

### DIFF
--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
@@ -1,15 +1,18 @@
 package com.xavelo.template.api.adapter.in.http.latency;
 
-import com.xavelo.api.dto.LatencyResponse;
-import com.xavelo.api.interfaces.LatencyApi;
+import com.xavelo.template.api.api.model.LatencyResponseDto;
 import com.xavelo.template.port.in.SynchExpensiveOperationUseCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class LatencyController implements LatencyApi {
+@RequestMapping(path = "/api")
+public class LatencyController {
 
     private static final Logger logger = LogManager.getLogger(LatencyController.class);
 
@@ -19,11 +22,11 @@ public class LatencyController implements LatencyApi {
         this.synchExpensiveOperationUseCase = synchExpensiveOperationUseCase;
     }
 
-    @Override
-    public ResponseEntity<LatencyResponse> getLatency() {
+    @GetMapping(path = "/latency", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<LatencyResponseDto> getLatency() {
         Long value = synchExpensiveOperationUseCase.blockingExpensiveOperation();
         logger.info("Latency endpoint executed expensive operation with result: {}", value);
-        LatencyResponse response = new LatencyResponse().value(value);
+        LatencyResponseDto response = new LatencyResponseDto().value(value);
         return ResponseEntity.ok(response);
     }
 }

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
@@ -1,26 +1,29 @@
 package com.xavelo.template.api.adapter.in.http.ping;
 
-import com.xavelo.api.dto.PingResponse;
-import com.xavelo.api.interfaces.PingApi;
+import com.xavelo.template.api.api.model.PingResponseDto;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class PingController implements PingApi {
+@RequestMapping(path = "/api")
+public class PingController {
 
     private static final Logger logger = LogManager.getLogger(PingController.class);
 
     @Value("${HOSTNAME:unknown}")
     private String podName;
 
-    @Override
-    public ResponseEntity<PingResponse> getPing() {
+    @GetMapping(path = "/ping", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<PingResponseDto> getPing() {
         String message = "pong from " + podName;
         logger.info("Responding to /api/ping with message: {}", message);
-        PingResponse response = new PingResponse().message(message);
+        PingResponseDto response = new PingResponseDto().message(message);
         return ResponseEntity.ok(response);
     }
 }

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
@@ -1,26 +1,29 @@
 package com.xavelo.template.api.adapter.in.http.secure;
 
-import com.xavelo.api.dto.PingResponse;
-import com.xavelo.api.interfaces.SecurePingApi;
+import com.xavelo.template.api.api.model.PingResponseDto;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class SecurePingController implements SecurePingApi {
+@RequestMapping(path = "/api")
+public class SecurePingController {
 
     private static final Logger logger = LogManager.getLogger(SecurePingController.class);
 
     @Value("${HOSTNAME:unknown}")
     private String podName;
 
-    @Override
-    public ResponseEntity<PingResponse> getSecurePing() {
+    @GetMapping(path = "/secure/ping", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<PingResponseDto> getSecurePing() {
         String message = "pong from " + podName;
         logger.info("Responding to /api/secure/ping with message: {}", message);
-        PingResponse response = new PingResponse().message(message);
+        PingResponseDto response = new PingResponseDto().message(message);
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## Summary
- replace usages of deleted OpenAPI interfaces with explicit Spring MVC request mappings
- return the generated OpenAPI DTOs from ping and latency controllers so the application module compiles

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d93363e9748329ad177fdeb95e2cfc