### PR TITLE
Generate OpenAPI contract zip and consume in application

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,6 +14,8 @@
     <name>template-api</name>
     <description>Template API</description>
 
+    <packaging>jar</packaging>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -54,34 +56,82 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>7.5.0</version>
+                <version>${openapi.generator.version}</version>
                 <executions>
                     <execution>
-                        <id>generate-api-models</id>
+                        <id>generate-openapi-contract</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
                             <inputSpec>${project.basedir}/src/main/resources/openapi/template-api.yaml</inputSpec>
-                            <generatorName>java</generatorName>
-                            <output>${project.build.directory}/generated-sources</output>
-                            <generateApis>false</generateApis>
+                            <generatorName>spring</generatorName>
+                            <output>${project.build.directory}/generated-sources/openapi</output>
+                            <generateApiDocumentation>false</generateApiDocumentation>
                             <generateApiTests>false</generateApiTests>
-                            <generateModelTests>false</generateModelTests>
                             <generateModelDocumentation>false</generateModelDocumentation>
-                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <generateModelTests>false</generateModelTests>
+                            <generateSupportingFiles>true</generateSupportingFiles>
                             <additionalProperties>
-                                <additionalProperty>modelPackage=com.xavelo.template.api.api.model</additionalProperty>
+                                <additionalProperty>apiPackage=com.xavelo.template.api.contract.api</additionalProperty>
+                                <additionalProperty>basePackage=com.xavelo.template.api.contract</additionalProperty>
+                                <additionalProperty>modelPackage=com.xavelo.template.api.contract.model</additionalProperty>
                                 <additionalProperty>dateLibrary=java8</additionalProperty>
                                 <additionalProperty>modelNameSuffix=Dto</additionalProperty>
                                 <additionalProperty>useJakartaEe=true</additionalProperty>
                                 <additionalProperty>serializationLibrary=jackson</additionalProperty>
-                                <additionalProperty>library=resttemplate</additionalProperty>
+                                <additionalProperty>useTags=true</additionalProperty>
+                                <additionalProperty>useSpringBoot3=true</additionalProperty>
                             </additionalProperties>
                             <configOptions>
                                 <sourceFolder>src/main/java</sourceFolder>
+                                <interfaceOnly>true</interfaceOnly>
                             </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>package-openapi-sources</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>${project.basedir}/src/main/assembly/openapi-sources.xml</descriptor>
+                            </descriptors>
+                            <finalName>${project.artifactId}-${project.version}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-openapi-zip</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/${project.artifactId}-${project.version}.zip</file>
+                                    <type>zip</type>
+                                    <classifier>openapi</classifier>
+                                </artifact>
+                            </artifacts>
                         </configuration>
                     </execution>
                 </executions>

--- a/api/src/main/assembly/openapi-sources.xml
+++ b/api/src/main/assembly/openapi-sources.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>openapi</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/generated-sources/openapi/src/main/java</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**/*.java</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -18,7 +18,8 @@
         <dependency>
             <groupId>com.xavelo.template.api</groupId>
             <artifactId>api</artifactId>
-            <version>TRUNK-SNAPSHOT</version>
+            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -45,6 +46,51 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-api-contract</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.xavelo.template.api</groupId>
+                                    <artifactId>api</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>openapi</classifier>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}/generated-sources/openapi</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>add-unpacked-openapi-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/openapi</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
@@ -1,18 +1,15 @@
 package com.xavelo.template.api.adapter.in.http.latency;
 
-import com.xavelo.template.api.api.model.LatencyResponseDto;
+import com.xavelo.template.api.contract.api.LatencyApi;
+import com.xavelo.template.api.contract.model.LatencyResponseDto;
 import com.xavelo.template.port.in.SynchExpensiveOperationUseCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(path = "/api")
-public class LatencyController {
+public class LatencyController implements LatencyApi {
 
     private static final Logger logger = LogManager.getLogger(LatencyController.class);
 
@@ -22,7 +19,7 @@ public class LatencyController {
         this.synchExpensiveOperationUseCase = synchExpensiveOperationUseCase;
     }
 
-    @GetMapping(path = "/latency", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Override
     public ResponseEntity<LatencyResponseDto> getLatency() {
         Long value = synchExpensiveOperationUseCase.blockingExpensiveOperation();
         logger.info("Latency endpoint executed expensive operation with result: {}", value);

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
@@ -1,25 +1,22 @@
 package com.xavelo.template.api.adapter.in.http.ping;
 
-import com.xavelo.template.api.api.model.PingResponseDto;
+import com.xavelo.template.api.contract.api.PingApi;
+import com.xavelo.template.api.contract.model.PingResponseDto;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(path = "/api")
-public class PingController {
+public class PingController implements PingApi {
 
     private static final Logger logger = LogManager.getLogger(PingController.class);
 
     @Value("${HOSTNAME:unknown}")
     private String podName;
 
-    @GetMapping(path = "/ping", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Override
     public ResponseEntity<PingResponseDto> getPing() {
         String message = "pong from " + podName;
         logger.info("Responding to /api/ping with message: {}", message);

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
@@ -1,25 +1,22 @@
 package com.xavelo.template.api.adapter.in.http.secure;
 
-import com.xavelo.template.api.api.model.PingResponseDto;
+import com.xavelo.template.api.contract.api.SecurePingApi;
+import com.xavelo.template.api.contract.model.PingResponseDto;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(path = "/api")
-public class SecurePingController {
+public class SecurePingController implements SecurePingApi {
 
     private static final Logger logger = LogManager.getLogger(SecurePingController.class);
 
     @Value("${HOSTNAME:unknown}")
     private String podName;
 
-    @GetMapping(path = "/secure/ping", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Override
     public ResponseEntity<PingResponseDto> getSecurePing() {
         String message = "pong from " + podName;
         logger.info("Responding to /api/secure/ping with message: {}", message);


### PR DESCRIPTION
## Summary
- switch the API module to generate Spring-based OpenAPI interfaces and DTOs
- package the generated sources into an attached ZIP artifact and unzip it in the application build
- update application controllers to implement the generated interfaces and use the shared DTOs

## Testing
- `mvn -pl application -am clean compile`


------
https://chatgpt.com/codex/tasks/task_e_68d93a20ba648329a06fe2536670dd50