### PR TITLE
Annotate HTTP adapters with adapter metadata

### DIFF
--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
@@ -2,6 +2,9 @@ package com.xavelo.template.api.adapter.in.http.latency;
 
 import com.xavelo.template.api.contract.api.LatencyApi;
 import com.xavelo.template.api.contract.model.LatencyResponseDto;
+import com.xavelo.template.metrics.Adapter;
+import com.xavelo.template.metrics.AdapterMetrics;
+import com.xavelo.template.metrics.CountAdapterInvocation;
 import com.xavelo.template.port.in.SynchExpensiveOperationUseCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Adapter(name = "latency-http-in", type = AdapterMetrics.Type.HTTP, direction = AdapterMetrics.Direction.IN)
 public class LatencyController implements LatencyApi {
 
     private static final Logger logger = LogManager.getLogger(LatencyController.class);
@@ -20,6 +24,10 @@ public class LatencyController implements LatencyApi {
     }
 
     @Override
+    @CountAdapterInvocation(
+            name = "latency-http-in",
+            type = AdapterMetrics.Type.HTTP,
+            direction = AdapterMetrics.Direction.IN)
     public ResponseEntity<LatencyResponseDto> getLatency() {
         Long value = synchExpensiveOperationUseCase.blockingExpensiveOperation();
         logger.info("Latency endpoint executed expensive operation with result: {}", value);

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
@@ -2,6 +2,9 @@ package com.xavelo.template.api.adapter.in.http.ping;
 
 import com.xavelo.template.api.contract.api.PingApi;
 import com.xavelo.template.api.contract.model.PingResponseDto;
+import com.xavelo.template.metrics.Adapter;
+import com.xavelo.template.metrics.AdapterMetrics;
+import com.xavelo.template.metrics.CountAdapterInvocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Adapter(name = "ping-http-in", type = AdapterMetrics.Type.HTTP, direction = AdapterMetrics.Direction.IN)
 public class PingController implements PingApi {
 
     private static final Logger logger = LogManager.getLogger(PingController.class);
@@ -17,6 +21,10 @@ public class PingController implements PingApi {
     private String podName;
 
     @Override
+    @CountAdapterInvocation(
+            name = "ping-http-in",
+            type = AdapterMetrics.Type.HTTP,
+            direction = AdapterMetrics.Direction.IN)
     public ResponseEntity<PingResponseDto> getPing() {
         String message = "pong from " + podName;
         logger.info("Responding to /api/ping with message: {}", message);

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
@@ -2,6 +2,9 @@ package com.xavelo.template.api.adapter.in.http.secure;
 
 import com.xavelo.template.api.contract.api.SecurePingApi;
 import com.xavelo.template.api.contract.model.PingResponseDto;
+import com.xavelo.template.metrics.Adapter;
+import com.xavelo.template.metrics.AdapterMetrics;
+import com.xavelo.template.metrics.CountAdapterInvocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Adapter(name = "secure-ping-http-in", type = AdapterMetrics.Type.HTTP, direction = AdapterMetrics.Direction.IN)
 public class SecurePingController implements SecurePingApi {
 
     private static final Logger logger = LogManager.getLogger(SecurePingController.class);
@@ -17,6 +21,10 @@ public class SecurePingController implements SecurePingApi {
     private String podName;
 
     @Override
+    @CountAdapterInvocation(
+            name = "secure-ping-http-in",
+            type = AdapterMetrics.Type.HTTP,
+            direction = AdapterMetrics.Direction.IN)
     public ResponseEntity<PingResponseDto> getSecurePing() {
         String message = "pong from " + podName;
         logger.info("Responding to /api/secure/ping with message: {}", message);

--- a/application/src/main/java/com/xavelo/template/metrics/Adapter.java
+++ b/application/src/main/java/com/xavelo/template/metrics/Adapter.java
@@ -1,0 +1,22 @@
+package com.xavelo.template.metrics;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Identifies a component as an adapter and provides descriptive metadata for metrics.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Adapter {
+
+    String name();
+
+    AdapterMetrics.Type type();
+
+    AdapterMetrics.Direction direction();
+}


### PR DESCRIPTION
## Summary
- add a reusable `@Adapter` annotation to capture adapter metadata alongside metrics
- mark the latency, ping, and secure ping HTTP controllers with the new adapter annotation in addition to invocation counting

## Testing
- `./mvnw -pl application test` *(fails: network is unreachable when downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ce35c7f483298f131dc6cb123ed7