### PR TITLE
Refactor adapter metrics into common module

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -17,6 +17,11 @@
     <dependencies>
         <dependency>
             <groupId>com.xavelo.template.api</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xavelo.template.api</groupId>
             <artifactId>api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -28,10 +33,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/latency/LatencyController.java
@@ -2,9 +2,9 @@ package com.xavelo.template.api.adapter.in.http.latency;
 
 import com.xavelo.template.api.contract.api.LatencyApi;
 import com.xavelo.template.api.contract.model.LatencyResponseDto;
-import com.xavelo.template.metrics.Adapter;
-import com.xavelo.template.metrics.AdapterMetrics;
-import com.xavelo.template.metrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.AdapterMetrics;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.template.port.in.SynchExpensiveOperationUseCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/ping/PingController.java
@@ -2,9 +2,9 @@ package com.xavelo.template.api.adapter.in.http.ping;
 
 import com.xavelo.template.api.contract.api.PingApi;
 import com.xavelo.template.api.contract.model.PingResponseDto;
-import com.xavelo.template.metrics.Adapter;
-import com.xavelo.template.metrics.AdapterMetrics;
-import com.xavelo.template.metrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.AdapterMetrics;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;

--- a/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/template/api/adapter/in/http/secure/SecurePingController.java
@@ -2,9 +2,9 @@ package com.xavelo.template.api.adapter.in.http.secure;
 
 import com.xavelo.template.api.contract.api.SecurePingApi;
 import com.xavelo.template.api.contract.model.PingResponseDto;
-import com.xavelo.template.metrics.Adapter;
-import com.xavelo.template.metrics.AdapterMetrics;
-import com.xavelo.template.metrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.AdapterMetrics;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;

--- a/application/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/application/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,0 @@
-com.xavelo.template.metrics.AdapterMetricsAutoConfiguration

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.xavelo.template.api</groupId>
+        <artifactId>spring-boot</artifactId>
+        <version>TRUNK-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>common</artifactId>
+    <name>template-common</name>
+    <description>Shared components for the template application</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/common/src/main/java/com/xavelo/common/metrics/Adapter.java
+++ b/common/src/main/java/com/xavelo/common/metrics/Adapter.java
@@ -1,4 +1,4 @@
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;

--- a/common/src/main/java/com/xavelo/common/metrics/AdapterMetrics.java
+++ b/common/src/main/java/com/xavelo/common/metrics/AdapterMetrics.java
@@ -1,4 +1,4 @@
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;

--- a/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAspect.java
+++ b/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAspect.java
@@ -1,4 +1,4 @@
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import java.time.Instant;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAutoConfiguration.java
+++ b/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAutoConfiguration.java
@@ -1,4 +1,4 @@
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;

--- a/common/src/main/java/com/xavelo/common/metrics/CountAdapterInvocation.java
+++ b/common/src/main/java/com/xavelo/common/metrics/CountAdapterInvocation.java
@@ -1,4 +1,4 @@
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/common/src/main/java/com/xavelo/common/metrics/EnableAdapterMetrics.java
+++ b/common/src/main/java/com/xavelo/common/metrics/EnableAdapterMetrics.java
@@ -1,4 +1,4 @@
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/common/src/main/java/com/xavelo/common/metrics/package-info.java
+++ b/common/src/main/java/com/xavelo/common/metrics/package-info.java
@@ -1,13 +1,13 @@
 /**
  * Provides annotations and support for instrumenting adapter invocations.
  * <p>
- * Add {@link com.xavelo.template.metrics.EnableAdapterMetrics @EnableAdapterMetrics}
+ * Add {@link com.xavelo.common.metrics.EnableAdapterMetrics @EnableAdapterMetrics}
  * to a Spring configuration class and annotate adapter methods with
- * {@link com.xavelo.template.metrics.CountAdapterInvocation @CountAdapterInvocation}
+ * {@link com.xavelo.common.metrics.CountAdapterInvocation @CountAdapterInvocation}
  * to automatically emit counters and timers tagged with the adapter name, type,
  * direction, and invocation result.
  */
 @NonNullApi
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import org.springframework.lang.NonNullApi;

--- a/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.xavelo.common.metrics.AdapterMetricsAutoConfiguration

--- a/common/src/test/java/com/xavelo/common/metrics/AdapterMetricsAspectTest.java
+++ b/common/src/test/java/com/xavelo/common/metrics/AdapterMetricsAspectTest.java
@@ -1,4 +1,4 @@
-package com.xavelo.template.metrics;
+package com.xavelo.common.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     </dependencyManagement>
 
     <modules>
+        <module>common</module>
         <module>api</module>
         <module>application</module>
     </modules>


### PR DESCRIPTION
## Summary
- add a reusable `common` module that houses the adapter metrics annotations, aspect and auto-configuration
- update the application module to depend on the shared metrics components and point HTTP adapters at the new package
- move the adapter metrics tests and auto-configuration metadata alongside the refactored code

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68e10fce2de48329bbf529c1199325d6