### PR TITLE
Add Grafana dashboard PoC assets

### DIFF
--- a/argocd/grafana/README.md
+++ b/argocd/grafana/README.md
@@ -1,0 +1,16 @@
+# Grafana Dashboard PoC
+
+This folder contains a proof-of-concept setup for managing Grafana dashboards as code.
+
+## Contents
+
+- `provisioning/dashboard-provider.yaml` &mdash; Provisioning manifest that instructs Grafana to load dashboards from a mounted directory.
+- `dashboards/sample-service-overview.json` &mdash; A minimal dashboard JSON that surfaces example HTTP metrics.
+
+## Usage
+
+1. Mount the `dashboards/` directory into the Grafana container at `/var/lib/grafana/dashboards/sample-service`.
+2. Mount the `provisioning/` directory at `/etc/grafana/provisioning/dashboards/`.
+3. Restart Grafana. The dashboard will appear under the **Sample Service** folder.
+
+This layout can be committed to source control and synced to Grafana through your GitOps pipeline.

--- a/argocd/grafana/dashboards/sample-service-overview.json
+++ b/argocd/grafana/dashboards/sample-service-overview.json
@@ -1,0 +1,67 @@
+{
+  "id": null,
+  "uid": "sample-service-overview",
+  "title": "Sample Service Overview",
+  "tags": ["sample", "poc"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "HTTP 2xx Rate",
+      "id": 1,
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{status=\"200\"}[5m]))",
+          "legendFormat": "2xx"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "graph",
+      "title": "HTTP Request Duration (p95)",
+      "id": 2,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95"
+        }
+      ],
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "type": "query",
+        "datasource": null,
+        "query": "label_values(kube_pod_info, namespace)",
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  }
+}

--- a/argocd/grafana/provisioning/dashboard-provider.yaml
+++ b/argocd/grafana/provisioning/dashboard-provider.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: sample-service
+    folder: Sample Service
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards/sample-service


### PR DESCRIPTION
## Summary
- add provisioning manifest that points Grafana at version-controlled dashboards
- provide a sample dashboard JSON and README describing how to use the PoC assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0c24bce448329a3fb4e060eba1c60