### PR TITLE
Implement mocked CRUD hexagonal flow

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -90,6 +90,38 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>generate-crud-openapi-contract</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/openapi/crud-api.yaml</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <output>${project.build.directory}/generated-sources/openapi</output>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateModelTests>false</generateModelTests>
+                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <additionalProperties>
+                                <additionalProperty>apiPackage=com.xavelo.template.api.contract.api</additionalProperty>
+                                <additionalProperty>basePackage=com.xavelo.template.api.contract</additionalProperty>
+                                <additionalProperty>modelPackage=com.xavelo.template.api.contract.model</additionalProperty>
+                                <additionalProperty>dateLibrary=java8</additionalProperty>
+                                <additionalProperty>modelNameSuffix=Dto</additionalProperty>
+                                <additionalProperty>useJakartaEe=true</additionalProperty>
+                                <additionalProperty>serializationLibrary=jackson</additionalProperty>
+                                <additionalProperty>useTags=true</additionalProperty>
+                                <additionalProperty>useSpringBoot3=true</additionalProperty>
+                            </additionalProperties>
+                            <configOptions>
+                                <sourceFolder>src/main/java</sourceFolder>
+                                <interfaceOnly>true</interfaceOnly>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/api/src/main/resources/openapi/crud-api.yaml
+++ b/api/src/main/resources/openapi/crud-api.yaml
@@ -12,7 +12,7 @@ paths:
   /api/crudobjects:
     get:
       tags:
-        - CrudObjects
+        - Crud
       operationId: listCrudObjects
       summary: Retrieves a paginated list of CrudObjects.
       parameters:
@@ -54,7 +54,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
     post:
       tags:
-        - CrudObjects
+        - Crud
       operationId: createCrudObject
       summary: Creates a new CrudObject.
       requestBody:
@@ -82,7 +82,7 @@ paths:
       - $ref: '#/components/parameters/CrudObjectIdPath'
     get:
       tags:
-        - CrudObjects
+        - Crud
       operationId: getCrudObject
       summary: Retrieves a single CrudObject by its identifier.
       responses:
@@ -100,7 +100,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
     put:
       tags:
-        - CrudObjects
+        - Crud
       operationId: replaceCrudObject
       summary: Replaces a CrudObject with the provided representation.
       requestBody:
@@ -130,7 +130,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
     patch:
       tags:
-        - CrudObjects
+        - Crud
       operationId: updateCrudObject
       summary: Applies a partial update to a CrudObject.
       requestBody:
@@ -160,7 +160,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
     delete:
       tags:
-        - CrudObjects
+        - Crud
       operationId: deleteCrudObject
       summary: Deletes a CrudObject by its identifier.
       responses:

--- a/application/src/main/java/com/xavelo/template/adapter/in/http/crud/CrudController.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/http/crud/CrudController.java
@@ -1,0 +1,84 @@
+package com.xavelo.template.adapter.in.http.crud;
+
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.AdapterMetrics;
+import com.xavelo.common.metrics.CountAdapterInvocation;
+import com.xavelo.template.api.contract.api.CrudApi;
+import com.xavelo.template.api.contract.model.CrudObjectCreateRequestDto;
+import com.xavelo.template.api.contract.model.CrudObjectDto;
+import com.xavelo.template.api.contract.model.CrudObjectPageDto;
+import com.xavelo.template.api.contract.model.CrudObjectPatchRequestDto;
+import com.xavelo.template.api.contract.model.CrudObjectUpdateRequestDto;
+import com.xavelo.template.application.port.in.CrudUseCase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@Adapter
+public class CrudController implements CrudApi {
+
+    private static final Logger logger = LogManager.getLogger(CrudController.class);
+
+    private final CrudUseCase crudUseCase;
+
+    public CrudController(CrudUseCase crudUseCase) {
+        this.crudUseCase = crudUseCase;
+    }
+
+    @CountAdapterInvocation(name = "crud-list", direction = AdapterMetrics.Direction.IN, type = AdapterMetrics.Type.HTTP)
+    @Override
+    public ResponseEntity<CrudObjectPageDto> listCrudObjects(Integer page, Integer size, String sort) {
+        CrudObjectPageDto response = crudUseCase.listCrudObjects(page, size, sort);
+        logger.info("Listing CrudObjects page={}, size={}, sort={}", page, size, sort);
+        return ResponseEntity.ok(response);
+    }
+
+    @CountAdapterInvocation(name = "crud-get", direction = AdapterMetrics.Direction.IN, type = AdapterMetrics.Type.HTTP)
+    @Override
+    public ResponseEntity<CrudObjectDto> getCrudObject(String crudObjectId) {
+        CrudObjectDto crudObject = crudUseCase.getCrudObject(crudObjectId);
+        logger.info("Retrieved CrudObject {}", crudObjectId);
+        return ResponseEntity.ok(crudObject);
+    }
+
+    @CountAdapterInvocation(name = "crud-create", direction = AdapterMetrics.Direction.IN, type = AdapterMetrics.Type.HTTP)
+    @Override
+    public ResponseEntity<Void> createCrudObject(CrudObjectCreateRequestDto crudObjectCreateRequestDto) {
+        CrudObjectDto created = crudUseCase.createCrudObject(crudObjectCreateRequestDto);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/{crudObjectId}")
+            .buildAndExpand(created.getId())
+            .toUri();
+        logger.info("Created CrudObject {}", created.getId());
+        return ResponseEntity.created(location).build();
+    }
+
+    @CountAdapterInvocation(name = "crud-replace", direction = AdapterMetrics.Direction.IN, type = AdapterMetrics.Type.HTTP)
+    @Override
+    public ResponseEntity<CrudObjectDto> replaceCrudObject(String crudObjectId, CrudObjectUpdateRequestDto crudObjectUpdateRequestDto) {
+        CrudObjectDto replaced = crudUseCase.replaceCrudObject(crudObjectId, crudObjectUpdateRequestDto);
+        logger.info("Replaced CrudObject {}", crudObjectId);
+        return ResponseEntity.ok(replaced);
+    }
+
+    @CountAdapterInvocation(name = "crud-update", direction = AdapterMetrics.Direction.IN, type = AdapterMetrics.Type.HTTP)
+    @Override
+    public ResponseEntity<CrudObjectDto> updateCrudObject(String crudObjectId, CrudObjectPatchRequestDto crudObjectPatchRequestDto) {
+        CrudObjectDto updated = crudUseCase.updateCrudObject(crudObjectId, crudObjectPatchRequestDto);
+        logger.info("Updated CrudObject {}", crudObjectId);
+        return ResponseEntity.ok(updated);
+    }
+
+    @CountAdapterInvocation(name = "crud-delete", direction = AdapterMetrics.Direction.IN, type = AdapterMetrics.Type.HTTP)
+    @Override
+    public ResponseEntity<Void> deleteCrudObject(String crudObjectId) {
+        crudUseCase.deleteCrudObject(crudObjectId);
+        logger.info("Deleted CrudObject {}", crudObjectId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/application/src/main/java/com/xavelo/template/adapter/in/http/crud/CrudControllerAdvice.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/http/crud/CrudControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.xavelo.template.adapter.in.http.crud;
+
+import com.xavelo.template.api.contract.model.ErrorResponseDto;
+import com.xavelo.template.application.exception.CrudObjectNotFoundException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = CrudController.class)
+public class CrudControllerAdvice {
+
+    private static final Logger logger = LogManager.getLogger(CrudControllerAdvice.class);
+
+    @ExceptionHandler(CrudObjectNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleNotFound(CrudObjectNotFoundException exception) {
+        logger.warn("CrudObject not found: {}", exception.getMessage());
+        ErrorResponseDto error = new ErrorResponseDto().message(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+}

--- a/application/src/main/java/com/xavelo/template/application/exception/CrudObjectNotFoundException.java
+++ b/application/src/main/java/com/xavelo/template/application/exception/CrudObjectNotFoundException.java
@@ -1,0 +1,11 @@
+package com.xavelo.template.application.exception;
+
+/**
+ * Signals that a CrudObject could not be located in the mocked data store.
+ */
+public class CrudObjectNotFoundException extends RuntimeException {
+
+    public CrudObjectNotFoundException(String crudObjectId) {
+        super("CrudObject with id '%s' was not found".formatted(crudObjectId));
+    }
+}

--- a/application/src/main/java/com/xavelo/template/application/port/in/CrudUseCase.java
+++ b/application/src/main/java/com/xavelo/template/application/port/in/CrudUseCase.java
@@ -1,0 +1,25 @@
+package com.xavelo.template.application.port.in;
+
+import com.xavelo.template.api.contract.model.CrudObjectCreateRequestDto;
+import com.xavelo.template.api.contract.model.CrudObjectDto;
+import com.xavelo.template.api.contract.model.CrudObjectPageDto;
+import com.xavelo.template.api.contract.model.CrudObjectPatchRequestDto;
+import com.xavelo.template.api.contract.model.CrudObjectUpdateRequestDto;
+
+/**
+ * Application port that exposes CRUD operations for {@link CrudObjectDto} resources.
+ */
+public interface CrudUseCase {
+
+    CrudObjectPageDto listCrudObjects(Integer page, Integer size, String sort);
+
+    CrudObjectDto getCrudObject(String crudObjectId);
+
+    CrudObjectDto createCrudObject(CrudObjectCreateRequestDto request);
+
+    CrudObjectDto replaceCrudObject(String crudObjectId, CrudObjectUpdateRequestDto request);
+
+    CrudObjectDto updateCrudObject(String crudObjectId, CrudObjectPatchRequestDto request);
+
+    void deleteCrudObject(String crudObjectId);
+}

--- a/application/src/main/java/com/xavelo/template/application/service/CrudService.java
+++ b/application/src/main/java/com/xavelo/template/application/service/CrudService.java
@@ -1,0 +1,216 @@
+package com.xavelo.template.application.service;
+
+import com.xavelo.template.api.contract.model.CrudObjectCreateRequestDto;
+import com.xavelo.template.api.contract.model.CrudObjectDto;
+import com.xavelo.template.api.contract.model.CrudObjectPageDto;
+import com.xavelo.template.api.contract.model.CrudObjectPatchRequestDto;
+import com.xavelo.template.api.contract.model.CrudObjectUpdateRequestDto;
+import com.xavelo.template.application.exception.CrudObjectNotFoundException;
+import com.xavelo.template.application.port.in.CrudUseCase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Mock implementation of {@link CrudUseCase} that keeps entities in memory.
+ */
+@Service
+public class CrudService implements CrudUseCase {
+
+    private static final Logger logger = LogManager.getLogger(CrudService.class);
+
+    private final Map<String, CrudRecord> dataStore = new ConcurrentHashMap<>();
+
+    public CrudService() {
+        seedData();
+    }
+
+    @Override
+    public CrudObjectPageDto listCrudObjects(Integer page, Integer size, String sort) {
+        int resolvedPage = page == null || page < 0 ? 0 : page;
+        int resolvedSize = size == null || size < 1 ? 20 : size;
+
+        List<CrudRecord> ordered = dataStore.values().stream()
+            .sorted(resolveComparator(sort))
+            .toList();
+
+        int totalElements = ordered.size();
+        int fromIndex = Math.min(resolvedPage * resolvedSize, totalElements);
+        int toIndex = Math.min(fromIndex + resolvedSize, totalElements);
+        List<CrudObjectDto> content = ordered.subList(fromIndex, toIndex).stream()
+            .map(this::toDto)
+            .toList();
+        int totalPages = resolvedSize == 0 ? 0 : (int) Math.ceil((double) totalElements / resolvedSize);
+
+        return new CrudObjectPageDto()
+            .content(new ArrayList<>(content))
+            .page(resolvedPage)
+            .size(resolvedSize)
+            .totalElements(totalElements)
+            .totalPages(totalPages);
+    }
+
+    @Override
+    public CrudObjectDto getCrudObject(String crudObjectId) {
+        CrudRecord record = findRequired(crudObjectId);
+        return toDto(record);
+    }
+
+    @Override
+    public CrudObjectDto createCrudObject(CrudObjectCreateRequestDto request) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        String id = UUID.randomUUID().toString();
+        CrudRecord record = new CrudRecord(id, request.getName(), extractDescription(request.getDescription()), now, now);
+        dataStore.put(id, record);
+        logger.info("Created CrudObject with id {}", id);
+        return toDto(record);
+    }
+
+    @Override
+    public CrudObjectDto replaceCrudObject(String crudObjectId, CrudObjectUpdateRequestDto request) {
+        CrudRecord existing = findRequired(crudObjectId);
+        existing.setName(request.getName());
+        existing.setDescription(extractDescription(request.getDescription()));
+        existing.setUpdatedAt(OffsetDateTime.now(ZoneOffset.UTC));
+        logger.info("Replaced CrudObject with id {}", crudObjectId);
+        return toDto(existing);
+    }
+
+    @Override
+    public CrudObjectDto updateCrudObject(String crudObjectId, CrudObjectPatchRequestDto request) {
+        CrudRecord existing = findRequired(crudObjectId);
+        if (request.getName() != null) {
+            existing.setName(request.getName());
+        }
+        JsonNullable<String> description = request.getDescription();
+        if (description != null && description.isPresent()) {
+            existing.setDescription(description.get());
+        }
+        existing.setUpdatedAt(OffsetDateTime.now(ZoneOffset.UTC));
+        logger.info("Patched CrudObject with id {}", crudObjectId);
+        return toDto(existing);
+    }
+
+    @Override
+    public void deleteCrudObject(String crudObjectId) {
+        CrudRecord removed = dataStore.remove(crudObjectId);
+        if (removed == null) {
+            throw new CrudObjectNotFoundException(crudObjectId);
+        }
+        logger.info("Deleted CrudObject with id {}", crudObjectId);
+    }
+
+    private CrudRecord findRequired(String crudObjectId) {
+        CrudRecord record = dataStore.get(crudObjectId);
+        if (record == null) {
+            throw new CrudObjectNotFoundException(crudObjectId);
+        }
+        return record;
+    }
+
+    private CrudObjectDto toDto(CrudRecord record) {
+        CrudObjectDto dto = new CrudObjectDto()
+            .id(record.getId())
+            .name(record.getName())
+            .createdAt(record.getCreatedAt())
+            .updatedAt(record.getUpdatedAt());
+        if (record.getDescription() != null) {
+            dto.description(record.getDescription());
+        }
+        return dto;
+    }
+
+    private Comparator<CrudRecord> resolveComparator(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return Comparator.comparing(CrudRecord::getName, String.CASE_INSENSITIVE_ORDER);
+        }
+        String[] parts = sort.split(",");
+        String property = parts[0].trim();
+        boolean descending = parts.length > 1 && "desc".equalsIgnoreCase(parts[1].trim());
+
+        Comparator<CrudRecord> comparator = switch (property) {
+            case "id" -> Comparator.comparing(CrudRecord::getId);
+            case "createdAt" -> Comparator.comparing(CrudRecord::getCreatedAt);
+            case "updatedAt" -> Comparator.comparing(CrudRecord::getUpdatedAt);
+            case "name" -> Comparator.comparing(CrudRecord::getName, String.CASE_INSENSITIVE_ORDER);
+            default -> Comparator.comparing(CrudRecord::getName, String.CASE_INSENSITIVE_ORDER);
+        };
+        return descending ? comparator.reversed() : comparator;
+    }
+
+    private String extractDescription(JsonNullable<String> description) {
+        if (description != null && description.isPresent()) {
+            return description.get();
+        }
+        return null;
+    }
+
+    private void seedData() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        store(new CrudRecord(UUID.randomUUID().toString(), "Alpha Object", "Mock object seeded at startup", now.minusDays(3), now.minusDays(1)));
+        store(new CrudRecord(UUID.randomUUID().toString(), "Beta Object", null, now.minusDays(2), now.minusHours(10)));
+        store(new CrudRecord(UUID.randomUUID().toString(), "Gamma Object", "Illustrative sample", now.minusDays(1), now.minusHours(2)));
+    }
+
+    private void store(CrudRecord record) {
+        dataStore.put(record.getId(), record);
+    }
+
+    private static final class CrudRecord {
+        private final String id;
+        private String name;
+        private String description;
+        private final OffsetDateTime createdAt;
+        private OffsetDateTime updatedAt;
+
+        private CrudRecord(String id, String name, String description, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+            this.id = id;
+            this.name = name;
+            this.description = description;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+        }
+
+        private String getId() {
+            return id;
+        }
+
+        private String getName() {
+            return name;
+        }
+
+        private String getDescription() {
+            return description;
+        }
+
+        private OffsetDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        private OffsetDateTime getUpdatedAt() {
+            return updatedAt;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+        }
+
+        private void setDescription(String description) {
+            this.description = description;
+        }
+
+        private void setUpdatedAt(OffsetDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- generate the CRUD OpenAPI interfaces alongside the existing contract and align the tag naming so a CrudApi is produced
- add a CrudUseCase port with an in-memory CrudService implementation that mocks all CRUD behaviours
- expose the CrudApi through a new CrudController and surface 404 responses via a dedicated controller advice

## Testing
- mvn -pl application -am test

------
https://chatgpt.com/codex/tasks/task_e_68e12f821cb08329be06745d4804c5bc